### PR TITLE
Fixes #10. xml parser for ObjC is loosing xml node level when encountering node without content

### DIFF
--- a/framework/xmls/template-objc.xml
+++ b/framework/xmls/template-objc.xml
@@ -356,12 +356,14 @@ this will be used to generate the class files for the complex types.
                         {% else %}
                         _readerOk = xmlTextReaderRead(reader);
                         _currentNodeType = xmlTextReaderNodeType(reader);
-                        const char *{{element.name}}ElementValue = (const char*) xmlTextReaderConstValue(reader);
-                        if({{element.name}}ElementValue) {
-                            {{ element.readCodeForContent }}
+                        if (_currentNodeType != XML_READER_TYPE_END_ELEMENT) {
+                            const char *{{element.name}}ElementValue = (const char*) xmlTextReaderConstValue(reader);
+                            if({{element.name}}ElementValue) {
+                                {{ element.readCodeForContent }}
+                            }
+                            _readerOk = xmlTextReaderRead(reader);
+                            _currentNodeType = xmlTextReaderNodeType(reader);
                         }
-                        _readerOk = xmlTextReaderRead(reader);
-                        _currentNodeType = xmlTextReaderNodeType(reader);
                         {% /if %}
                     } else {% /for %}{% if type.hasSimpleBaseClass %}if([@"#text" isEqualToString: _currentElementName]){
                         const char* contentValue = (const char*) xmlTextReaderConstValue(reader);

--- a/tests/xmls/MyPantry.xml
+++ b/tests/xmls/MyPantry.xml
@@ -7,7 +7,7 @@
 		<p:Food>
 			<p:Name>Apple</p:Name>
 			<p:FoodGroup>fruit</p:FoodGroup>
-            <p:Comment>Not empty comment</p:Comment>
+			<p:Comment></p:Comment>
 			<p:Cost>$0.50</p:Cost>
 		</p:Food>
 	</p:Shelf>

--- a/tests/xmls/MyPantry.xml
+++ b/tests/xmls/MyPantry.xml
@@ -7,6 +7,7 @@
 		<p:Food>
 			<p:Name>Apple</p:Name>
 			<p:FoodGroup>fruit</p:FoodGroup>
+            <p:Comment>Not empty comment</p:Comment>
 			<p:Cost>$0.50</p:Cost>
 		</p:Food>
 	</p:Shelf>

--- a/tests/xmls/MyPantry.xsd
+++ b/tests/xmls/MyPantry.xsd
@@ -21,6 +21,7 @@
 	<xs:complexType name="FoodItemType">
 		<xs:sequence>
 			<xs:element name="Name" type="xs:string" />
+			<xs:element name="Comment" type="xs:string" />
 			<xs:element name="FoodGroup" type="p:FoodGroupType" />
 			<xs:element name="Cost" type="xs:string" />
 		</xs:sequence>


### PR DESCRIPTION
Test data has been corrected to expose bug in ObjC template.
template was fixed to resolve this issue.
Fixed #10 
